### PR TITLE
Update CI workflow to Swift 6.0 and Xcode 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   ubuntu_test:
     name: Ubuntu Build & Test
     runs-on: ubuntu-22.04
-    container: swift:5.7.3-jammy
+    container: swift:6.0
     steps:
     - uses: actions/checkout@v3
     - name: Build
@@ -22,8 +22,8 @@ jobs:
   macos_test:
     name: macOS Build & Test
     env:
-      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
-    runs-on: macos-12
+      DEVELOPER_DIR: /Applications/Xcode_16.0.app/Contents/Developer
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v3
     - name: Build


### PR DESCRIPTION
Update the CI workflow to use Swift 6.0 and Xcode 16 for testing. This ensures that the project is compatible with the latest versions of the Swift language and Xcode development tools.