### PR TITLE
RFC 9126: OAuth 2.0 Pushed Authorization Requests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,24 @@
       }
     },
     {
+      "identity" : "redis",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/redis.git",
+      "state" : {
+        "revision" : "383ed57e5b5acd4dd447c2967aa665dc3bbe5be9",
+        "version" : "4.11.0"
+      }
+    },
+    {
+      "identity" : "redistack",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/RediStack.git",
+      "state" : {
+        "revision" : "622ce440f90d79b58e45f3a3efdd64c51d1dfd17",
+        "version" : "1.6.2"
+      }
+    },
+    {
       "identity" : "routing-kit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/routing-kit.git",

--- a/Package.swift
+++ b/Package.swift
@@ -10,24 +10,48 @@ let package = Package(
         .library(
             name: "OAuth",
             targets: ["VaporOAuth"]
+        ),
+        .library(
+            name: "OAuthPAR", 
+            targets: ["VaporOAuthPAR"]
         )
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.106.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.8.1")
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.8.1"),
+        .package(url: "https://github.com/vapor/redis.git", from: "4.11.0")
     ],
     targets: [
         .target(
             name: "VaporOAuth",
-            dependencies: [.product(name: "Vapor", package: "vapor"), .product(name: "Crypto", package: "swift-crypto")],
+            dependencies: [
+                .product(name: "Vapor", package: "vapor"),
+                .product(name: "Crypto", package: "swift-crypto")
+            ],
             swiftSettings: [
                 .enableUpcomingFeature("BareSlashRegexLiterals"),
                 .enableExperimentalFeature("StrictConcurrency=complete"),
             ]
         ),
-        .testTarget(name: "VaporOAuthTests", dependencies: [
-            .target(name: "VaporOAuth"),
-            .product(name: "XCTVapor", package: "vapor")
-        ])
+        .target(
+            name: "VaporOAuthPAR",
+            dependencies: [
+                .target(name: "VaporOAuth"),
+                .product(name: "Vapor", package: "vapor"),
+                .product(name: "Redis", package: "redis")
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("BareSlashRegexLiterals"),
+                .enableExperimentalFeature("StrictConcurrency=complete"),
+            ]
+        ),
+        .testTarget(
+            name: "VaporOAuthTests",
+            dependencies: [
+                .target(name: "VaporOAuth"),
+                .target(name: "VaporOAuthPAR"),
+                .product(name: "XCTVapor", package: "vapor")
+            ]
+        )
     ]
 )

--- a/Sources/VaporOAuth/OAuth2.swift
+++ b/Sources/VaporOAuth/OAuth2.swift
@@ -40,13 +40,13 @@ public struct OAuth2: LifecycleHandler {
 
     private func addRoutes(to app: Application) {
         let scopeValidator = ScopeValidator(validScopes: validScopes, clientRetriever: clientRetriever)
-
+        
         let clientValidator = ClientValidator(
             clientRetriever: clientRetriever,
             scopeValidator: scopeValidator,
             environment: app.environment
         )
-
+        
         let tokenHandler = TokenHandler(
             clientValidator: clientValidator,
             tokenManager: tokenManager,
@@ -56,13 +56,13 @@ public struct OAuth2: LifecycleHandler {
             userManager: userManager,
             logger: app.logger
         )
-
+        
         let tokenIntrospectionHandler = TokenIntrospectionHandler(
             clientValidator: clientValidator,
             tokenManager: tokenManager,
             userManager: userManager
         )
-
+        
         let authorizeGetHandler = AuthorizeGetHandler(
             authorizeHandler: authorizeHandler,
             clientValidator: clientValidator
@@ -78,21 +78,40 @@ public struct OAuth2: LifecycleHandler {
             clientValidator: clientValidator,
             scopeValidator: scopeValidator
         )
-
+        
         let resourceServerAuthenticator = ResourceServerAuthenticator(resourceServerRetriever: resourceServerRetriever)
-
+        
         // returning something like "Authenticate with GitHub page"
         app.get("oauth", "authorize", use: authorizeGetHandler.handleRequest)
         // pressing something like "Allow/Deny Access" button on "Authenticate with GitHub page". Returns a code.
         app.grouped(OAuthUser.guardMiddleware()).post("oauth", "authorize", use: authorizePostHandler.handleRequest)
-    
+        
         app.post("oauth", "device_authorization", use: deviceAuthorizationHandler.handleRequest)
-    
+        
         // client requesting access/refresh token with code from POST /authorize endpoint
         app.post("oauth", "token", use: tokenHandler.handleRequest)
-
+        
         let tokenIntrospectionAuthMiddleware = TokenIntrospectionAuthMiddleware(resourceServerAuthenticator: resourceServerAuthenticator)
         let resourceServerProtected = app.routes.grouped(tokenIntrospectionAuthMiddleware)
         resourceServerProtected.post("oauth", "token_info", use: tokenIntrospectionHandler.handleRequest)
+    }
+}
+
+public extension OAuth2 {
+    func makeClientValidator() -> ClientValidator {
+        return ClientValidator(
+            clientRetriever: self.clientRetriever,
+            scopeValidator: ScopeValidator(validScopes: self.validScopes, clientRetriever: self.clientRetriever),
+            environment: .development
+        )
+    }
+    func makeAuthorizeGetHandler() -> AuthorizeGetHandler {
+        return AuthorizeGetHandler(
+            authorizeHandler: self.authorizeHandler,
+            clientValidator: self.makeClientValidator()
+        )
+    }
+    func getAuthorizeHandler() -> AuthorizeHandler {
+        return self.authorizeHandler
     }
 }

--- a/Sources/VaporOAuth/RouteHandlers/AuthorizeGetHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/AuthorizeGetHandler.swift
@@ -1,11 +1,11 @@
 import Vapor
 
-struct AuthorizeGetHandler: Sendable {
+public struct AuthorizeGetHandler: Sendable {
     let authorizeHandler: AuthorizeHandler
     let clientValidator: ClientValidator
 
     @Sendable
-    func handleRequest(request: Request) async throws -> Response {
+    public func handleRequest(request: Request) async throws -> Response {
         let (errorResponse, createdAuthRequestObject) = try await validateRequest(request)
 
         if let errorResponseReturned = errorResponse {

--- a/Sources/VaporOAuth/RouteHandlers/DeviceAuthorizationHandler.swift
+++ b/Sources/VaporOAuth/RouteHandlers/DeviceAuthorizationHandler.swift
@@ -129,13 +129,13 @@ struct DeviceAuthorizationHandler: Sendable {
 
 // MARK: - Request/Response Models
 extension DeviceAuthorizationHandler {
-    struct DeviceAuthorizationRequest: Sendable {
+   public struct DeviceAuthorizationRequest: Sendable {
         let clientID: String
         let clientSecret: String?
         let scopes: [String]?
     }
     
-    struct DeviceResponse: Content, Sendable {
+    public struct DeviceResponse: Content, Sendable {
         let deviceCode: String
         let userCode: String
         let verificationURI: String
@@ -153,7 +153,7 @@ extension DeviceAuthorizationHandler {
         }
     }
     
-    struct ErrorResponse: Content, Sendable {
+    public struct ErrorResponse: Content, Sendable {
         let error: String
         let errorDescription: String
         

--- a/Sources/VaporOAuth/Utilities/StringDefines.swift
+++ b/Sources/VaporOAuth/Utilities/StringDefines.swift
@@ -1,10 +1,10 @@
-struct OAuthRequestParameters: Sendable {
-    static let clientID = "client_id"
-    static let clientSecret = "client_secret"
-    static let redirectURI = "redirect_uri"
-    static let responseType = "response_type"
-    static let scope = "scope"
-    static let state = "state"
+public struct OAuthRequestParameters: Sendable {
+    public static let clientID = "client_id"
+    public static let clientSecret = "client_secret"
+    public static let redirectURI = "redirect_uri"
+    public static let responseType = "response_type"
+    public static let scope = "scope"
+    public static let state = "state"
     static let applicationAuthorized = "applicationAuthorized"
     static let grantType = "grant_type"
     static let refreshToken = "refresh_token"
@@ -13,13 +13,13 @@ struct OAuthRequestParameters: Sendable {
     static let usernname = "username"
     static let csrfToken = "csrfToken"
     static let token = "token"
-    static let codeChallenge = "code_challenge"
-    static let codeChallengeMethod = "code_challenge_method"
+    public static let codeChallenge = "code_challenge"
+    public static let codeChallengeMethod = "code_challenge_method"
     static let codeVerifier = "code_verifier"
     static let deviceCode = "device_code"  
 }
 
-struct OAuthResponseParameters: Sendable {
+public struct OAuthResponseParameters: Sendable {
 
     static let error = "error"
     static let errorDescription = "error_description"

--- a/Sources/VaporOAuth/Validators/ClientValidator.swift
+++ b/Sources/VaporOAuth/Validators/ClientValidator.swift
@@ -1,10 +1,16 @@
 import Vapor
 
-struct ClientValidator: Sendable {
+public struct ClientValidator: Sendable {
 
     let clientRetriever: ClientRetriever
     let scopeValidator: ScopeValidator
-    let environment: Environment
+    public let environment: Environment
+
+    public init(clientRetriever: ClientRetriever, scopeValidator: ScopeValidator, environment: Environment) {
+        self.clientRetriever = clientRetriever
+        self.scopeValidator = scopeValidator
+        self.environment = environment
+    }   
 
     func validateClient(clientID: String, responseType: String, redirectURI: String, scopes: [String]?) async throws {
         guard let client = try await clientRetriever.getClient(clientID: clientID) else {
@@ -42,7 +48,7 @@ struct ClientValidator: Sendable {
         }
     }
 
-    func authenticateClient(clientID: String, clientSecret: String?, grantType: OAuthFlowType?,
+    public func authenticateClient(clientID: String, clientSecret: String?, grantType: OAuthFlowType?,
                             checkConfidentialClient: Bool = false) async throws {
         guard let client = try await clientRetriever.getClient(clientID: clientID) else {
             throw ClientError.unauthorized

--- a/Sources/VaporOAuth/Validators/ScopeValidator.swift
+++ b/Sources/VaporOAuth/Validators/ScopeValidator.swift
@@ -1,6 +1,11 @@
-struct ScopeValidator: Sendable {
+public struct ScopeValidator: Sendable {
     let validScopes: [String]?
     let clientRetriever: ClientRetriever
+
+    public init(validScopes: [String]?, clientRetriever: ClientRetriever) {
+        self.validScopes = validScopes
+        self.clientRetriever = clientRetriever
+    }
 
     func validateScope(clientID: String, scopes: [String]?) async throws {
         if let requestedScopes = scopes {

--- a/Sources/VaporOAuthPAR/Configuration/PARConfiguration.swift
+++ b/Sources/VaporOAuthPAR/Configuration/PARConfiguration.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct PARConfiguration: Sendable {
+    /// The prefix for request URIs
+    public let requestURIPrefix: String
+    
+    /// How long PAR requests are valid for (in seconds)
+    public let expiresIn: Int
+    
+    /// Maximum allowed size of the request (in bytes)
+    public let maxRequestSize: Int
+    
+    public init(
+        requestURIPrefix: String = "urn:ietf:params:oauth:request_uri:",
+        expiresIn: Int = 60,
+        maxRequestSize: Int = 50_000
+    ) {
+        self.requestURIPrefix = requestURIPrefix
+        self.expiresIn = expiresIn
+        self.maxRequestSize = maxRequestSize
+    }
+}

--- a/Sources/VaporOAuthPAR/Extensions/OAuth2+PAR.swift
+++ b/Sources/VaporOAuthPAR/Extensions/OAuth2+PAR.swift
@@ -1,0 +1,62 @@
+import Vapor
+import VaporOAuth
+
+public extension OAuth2 {
+    func enablePAR(
+        app: Application,
+        storage: PARRequestStorage,
+        configuration: PARConfiguration = PARConfiguration()
+    ) {
+        // Create PAR handler with injected dependencies
+        let parHandler = PARHandler(
+            clientValidator: self.makeClientValidator(),
+            storage: storage,
+            configuration: configuration
+        )
+        
+        // Register PAR endpoint
+        app.post("oauth", "par") { req in
+            try await parHandler.handlePARRequest(req)
+        }
+        
+        // Create authorize handler wrapper
+        let authorizeGetHandler = self.makeAuthorizeGetHandler()
+        
+        // Extend authorize endpoint to support PAR
+        let existingHandler = app.routes.all.first { $0.path == ["oauth", "authorize"] }
+        existingHandler?.responder = PARAuthorizeResponder(
+            storage: storage,
+            authorizeHandler: self.getAuthorizeHandler(),
+            fallbackHandler: authorizeGetHandler
+        )
+    }
+}
+
+private struct PARAuthorizeResponder: AsyncResponder {
+    let storage: PARRequestStorage
+    let authorizeHandler: AuthorizeHandler
+    let fallbackHandler: AuthorizeGetHandler
+    
+    func respond(to request: Request) async throws -> Response {
+        if let requestURI = try? request.query.get(String.self, at: "request_uri") {
+            guard let parRequest = try await storage.retrieve(requestURI: requestURI) else {
+                throw Abort(.badRequest, reason: "Invalid request_uri")
+            }
+            
+            // Convert PARRequest to AuthorizationRequestObject
+            let authRequest = AuthorizationRequestObject(
+                responseType: parRequest.responseType,
+                clientID: parRequest.clientID,
+                redirectURI: URI(string: parRequest.redirectURI),
+                scope: parRequest.scope,
+                state: parRequest.state,
+                csrfToken: [UInt8].random(count: 32).hex,
+                codeChallenge: parRequest.codeChallenge,
+                codeChallengeMethod: parRequest.codeChallengeMethod
+            )
+            
+            return try await authorizeHandler.handleAuthorizationRequest(request, authorizationRequestObject: authRequest)
+        }
+        return try await fallbackHandler.handleRequest(request: request)
+    }
+}

--- a/Sources/VaporOAuthPAR/Handlers/PARHandler.swift
+++ b/Sources/VaporOAuthPAR/Handlers/PARHandler.swift
@@ -1,0 +1,98 @@
+import Vapor
+import VaporOAuth
+
+public struct PARHandler : Sendable {
+    private let clientValidator: ClientValidator
+    private let storage: PARRequestStorage
+    private let configuration: PARConfiguration
+    private let validator: PARRequestValidator
+    
+    public init(
+        clientValidator: ClientValidator,
+        storage: PARRequestStorage,
+        configuration: PARConfiguration,
+        validator: PARRequestValidator = PARRequestValidator()
+    ) {
+        self.clientValidator = clientValidator
+        self.storage = storage
+        self.configuration = configuration
+        self.validator = validator
+    }
+    
+    @Sendable
+    public func handlePARRequest(_ req: Request) async throws -> Response {
+        // Validate request size first
+        guard let contentLength = req.headers.first(name: .contentLength),
+              Int(contentLength) ?? 0 <= configuration.maxRequestSize else {
+            let response = Response(status: .badRequest)
+            try response.content.encode(ErrorResponse(
+                error: "invalid_request",
+                errorDescription: "Request exceeds maximum allowed size"
+            ))
+            return response
+        }
+        
+        // Check required parameters
+        guard let clientID = req.content[String.self, at: OAuthRequestParameters.clientID] else {
+            let response = Response(status: .badRequest)
+            try response.content.encode(ErrorResponse(
+                error: "invalid_request",
+                errorDescription: "Missing client_id parameter"
+            ))
+            return response
+        }
+        
+        // Authenticate client
+        do {
+            try await clientValidator.authenticateClient(
+                clientID: clientID,
+                clientSecret: req.content[String.self, at: OAuthRequestParameters.clientSecret],
+                grantType: .authorization
+            )
+        } catch {
+            let response = Response(status: .unauthorized)
+            try response.content.encode(ErrorResponse(
+                error: "invalid_client",
+                errorDescription: "Invalid client credentials"
+            ))
+            return response
+        }
+        
+        // Validate request parameters
+        let parRequest: PARRequest
+        do {
+            parRequest = try await validator.validateRequest(req)
+        } catch {
+            let response = Response(status: .badRequest)
+            try response.content.encode(ErrorResponse(
+                error: "invalid_request",
+                errorDescription: "Invalid request parameters"
+            ))
+            return response
+        }
+        
+        // Generate request URI and store the request
+        let requestURI = "\(configuration.requestURIPrefix)\(UUID().uuidString)"
+        try await storage.store(parRequest, withURI: requestURI)
+        
+        // Return success response
+        let response = Response(status: .created)
+        try response.content.encode(
+            PushedAuthorizationRequest(
+                requestURI: requestURI,
+                expiresIn: configuration.expiresIn
+            )
+        )
+        return response
+    }
+}
+
+struct ErrorResponse: Content, Sendable {
+    let error: String
+    let errorDescription: String
+    
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+    }
+}

--- a/Sources/VaporOAuthPAR/Models/PARError.swift
+++ b/Sources/VaporOAuthPAR/Models/PARError.swift
@@ -1,0 +1,26 @@
+import Vapor
+
+public enum PARError: AbortError, Equatable {
+    case invalidRequest(reason: String)
+    case requestTooLarge
+    case unsupportedGrantType
+    case invalidClient
+    
+    public var status: HTTPStatus {
+        switch self {
+        case .invalidRequest: return .badRequest
+        case .requestTooLarge: return .payloadTooLarge  // 413
+        case .unsupportedGrantType: return .badRequest
+        case .invalidClient: return .unauthorized
+        }
+    }
+    
+    public var reason: String {
+        switch self {
+        case .invalidRequest(let reason): return reason
+        case .requestTooLarge: return "Request exceeds maximum allowed size"
+        case .unsupportedGrantType: return "Unsupported grant type"
+        case .invalidClient: return "Invalid client credentials"
+        }
+    }
+}

--- a/Sources/VaporOAuthPAR/Models/PARRequest.swift
+++ b/Sources/VaporOAuthPAR/Models/PARRequest.swift
@@ -1,0 +1,34 @@
+import Vapor
+import VaporOAuth
+
+public struct PARRequest: Content, Sendable {
+    public let responseType: String
+    public let clientID: String
+    public let redirectURI: String
+    public let scope: [String]
+    public let state: String?
+    public let codeChallenge: String?
+    public let codeChallengeMethod: String?
+    public let createdAt: Date
+
+    public init(
+        responseType: String,
+        clientID: String,
+        redirectURI: String,
+        scope: [String],
+        state: String? = nil,
+        codeChallenge: String? = nil,
+        codeChallengeMethod: String? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.responseType = responseType
+        self.clientID = clientID
+        self.redirectURI = redirectURI
+        self.scope = scope
+        self.state = state
+        self.codeChallenge = codeChallenge
+        self.codeChallengeMethod = codeChallengeMethod
+        self.createdAt = createdAt
+    }
+}
+    

--- a/Sources/VaporOAuthPAR/Models/PushedAuthorizationRequest.swift
+++ b/Sources/VaporOAuthPAR/Models/PushedAuthorizationRequest.swift
@@ -1,0 +1,16 @@
+import Vapor
+
+public struct PushedAuthorizationRequest: Content {
+    public let requestURI: String
+    public let expiresIn: Int
+    
+    public init(requestURI: String, expiresIn: Int) {
+        self.requestURI = requestURI
+        self.expiresIn = expiresIn
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case requestURI = "request_uri"
+        case expiresIn = "expires_in"
+    }
+}

--- a/Sources/VaporOAuthPAR/Protocols/PARRequestStorage.swift
+++ b/Sources/VaporOAuthPAR/Protocols/PARRequestStorage.swift
@@ -1,0 +1,16 @@
+import Vapor
+import VaporOAuth
+
+public protocol PARRequestStorage: Sendable {
+    /// Store a PAR request with its associated URI
+    func store(_ request: PARRequest, withURI requestURI: String) async throws
+    
+    /// Retrieve a PAR request by its URI
+    func retrieve(requestURI: String) async throws -> PARRequest?
+    
+    /// Remove a PAR request (should be called after use or expiration)
+    func remove(requestURI: String) async throws
+    
+    /// Clean up expired requests
+    func removeExpired() async throws
+}

--- a/Sources/VaporOAuthPAR/Storage/InMemoryPARStorage.swift
+++ b/Sources/VaporOAuthPAR/Storage/InMemoryPARStorage.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Vapor
+
+public actor InMemoryPARStorage: PARRequestStorage {
+    private var storage: [String: (request: PARRequest, expiresAt: Date)]
+    private let expirationInterval: TimeInterval
+    
+    public init(expirationInterval: TimeInterval = 60) {
+        self.storage = [:]
+        self.expirationInterval = expirationInterval
+    }
+    
+    public func store(_ request: PARRequest, withURI requestURI: String) async throws {
+        let expiresAt = Date().addingTimeInterval(expirationInterval)
+        storage[requestURI] = (request, expiresAt)
+    }
+    
+    public func retrieve(requestURI: String) async throws -> PARRequest? {
+        guard let (request, expiresAt) = storage[requestURI] else {
+            return nil
+        }
+        
+        // Check if expired
+        guard expiresAt > Date() else {
+            try await remove(requestURI: requestURI)
+            return nil
+        }
+        
+        return request
+    }
+    
+    public func remove(requestURI: String) async throws {
+        storage.removeValue(forKey: requestURI)
+    }
+    
+    public func removeExpired() async throws {
+        let now = Date()
+        storage = storage.filter { $0.value.expiresAt > now }
+    }
+}
+

--- a/Sources/VaporOAuthPAR/Storage/RedisPARStorage.swift
+++ b/Sources/VaporOAuthPAR/Storage/RedisPARStorage.swift
@@ -1,0 +1,38 @@
+import Redis
+import Vapor
+import Foundation
+
+public actor RedisPARStorage: PARRequestStorage {
+    private let redis: RedisClient
+    private let keyPrefix: String
+    private let expirationInterval: Int
+    
+    public init(redis: RedisClient, keyPrefix: String = "par:", expirationInterval: Int = 60) {
+        self.redis = redis
+        self.keyPrefix = keyPrefix
+        self.expirationInterval = expirationInterval
+    }
+    
+    public func store(_ request: PARRequest, withURI requestURI: String) async throws {
+        let key = RedisKey(stringLiteral: "\(keyPrefix)\(requestURI)")
+        let data = try JSONEncoder().encode(request)
+        try await redis.setex(key, to: data, expirationInSeconds: expirationInterval).get()
+    }
+    
+    public func retrieve(requestURI: String) async throws -> PARRequest? {
+        let key = RedisKey(stringLiteral: "\(keyPrefix)\(requestURI)")
+        guard let data = try await redis.get(key, as: Data.self).get() else {
+            return nil
+        }
+        return try JSONDecoder().decode(PARRequest.self, from: data)
+    }
+    
+    public func remove(requestURI: String) async throws {
+        let key = RedisKey(stringLiteral: "\(keyPrefix)\(requestURI)")
+        _ = try await redis.delete(key).get()
+    }
+    
+    public func removeExpired() async throws {
+        // Redis automatically removes expired keys, so no additional implementation needed
+    }
+}

--- a/Sources/VaporOAuthPAR/Utilities/PARConstants.swift
+++ b/Sources/VaporOAuthPAR/Utilities/PARConstants.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public enum PARConstants {
+    public static let defaultExpirationInterval: TimeInterval = 60
+    public static let maxRequestSize: Int = 50_000
+    public static let endpointPath = "oauth/par"
+    
+    public enum Parameters {
+        public static let requestURI = "request_uri"
+        public static let expiresIn = "expires_in"
+    }
+    
+    public enum Headers {
+        public static let contentType = "application/x-www-form-urlencoded"
+    }
+}

--- a/Sources/VaporOAuthPAR/Utilities/PARRequestValidator.swift
+++ b/Sources/VaporOAuthPAR/Utilities/PARRequestValidator.swift
@@ -1,0 +1,29 @@
+import Vapor 
+import VaporOAuth 
+
+public struct PARRequestValidator: Sendable { 
+    public init() {} 
+    
+    public func validateRequest(_ req: Request) async throws -> PARRequest { 
+        // Validate required parameters 
+        guard let responseType = req.content[String.self, at: OAuthRequestParameters.responseType], let clientID = req.content[String.self, at: OAuthRequestParameters.clientID], let redirectURI = req.content[String.self, at: OAuthRequestParameters.redirectURI] else { 
+            throw PARError.invalidRequest(reason: "Missing required parameters") 
+            } // Validate response type 
+            guard responseType == "code" || responseType == "token" else {
+            throw PARError.invalidRequest(reason: "Invalid response_type") 
+        } 
+        // Parse scopes 
+        let scopeString = req.content[String.self, at: OAuthRequestParameters.scope] ?? ""
+        let scopes = scopeString.split(separator: " ").map(String.init) 
+        // Create PAR request 
+        return PARRequest(
+            responseType: responseType, 
+            clientID: clientID, 
+            redirectURI: redirectURI, 
+            scope: scopes, 
+            state: req.content[String.self, at: OAuthRequestParameters.state], 
+            codeChallenge: req.content[String.self, at: OAuthRequestParameters.codeChallenge], 
+            codeChallengeMethod: req.content[String.self, at: OAuthRequestParameters.codeChallengeMethod] 
+        ) 
+    }
+}

--- a/Tests/VaporOAuthTests/Fakes/FakeClientGetter.swift
+++ b/Tests/VaporOAuthTests/Fakes/FakeClientGetter.swift
@@ -1,10 +1,10 @@
 import VaporOAuth
 
-class FakeClientGetter: ClientRetriever, @unchecked Sendable {
+public class FakeClientGetter: ClientRetriever, @unchecked Sendable {
     
     var validClients: [String: OAuthClient] = [:]
     
-    func getClient(clientID: String) async throws -> OAuthClient? {
+    public func getClient(clientID: String) async throws -> OAuthClient? {
         return validClients[clientID]
     }
 }

--- a/Tests/VaporOAuthTests/Fakes/FakePARStorage.swift
+++ b/Tests/VaporOAuthTests/Fakes/FakePARStorage.swift
@@ -1,0 +1,28 @@
+import Foundation
+import VaporOAuthPAR 
+
+class FakePARStorage: PARRequestStorage { 
+    var storedRequests: [String: PARRequest] = [:] 
+    var storeCallCount = 0 
+    var retrieveCallCount = 0 
+    var removeCallCount = 0 
+    
+    func store(_ request: PARRequest, withURI requestURI: String) async throws { 
+        storeCallCount += 1 
+        storedRequests[requestURI] = request 
+    } 
+        
+    func retrieve(requestURI: String) async throws -> PARRequest? { 
+        retrieveCallCount += 1 
+        return storedRequests[requestURI] 
+    } 
+            
+    func remove(requestURI: String) async throws { 
+        removeCallCount += 1
+        storedRequests.removeValue(forKey: requestURI)
+    }
+
+    func removeExpired() async throws { 
+        // No-op
+    }
+}

--- a/Tests/VaporOAuthTests/Helpers/Responses.swift
+++ b/Tests/VaporOAuthTests/Helpers/Responses.swift
@@ -1,7 +1,7 @@
-struct ErrorResponse: Decodable {
+public struct ErrorResponse: Decodable {
     var error: String
     var errorDescription: String
-
+    
     enum CodingKeys: String, CodingKey {
         case error
         case errorDescription = "error_description"
@@ -14,7 +14,7 @@ struct SuccessResponse: Decodable {
     var accessToken: String?
     var refreshToken: String?
     var scope: String?
-
+    
     enum CodingKeys: String, CodingKey {
         case tokenType = "token_type"
         case expiresIn = "expires_in"
@@ -22,4 +22,4 @@ struct SuccessResponse: Decodable {
         case refreshToken = "refresh_token"
         case scope
     }
-    }
+}


### PR DESCRIPTION
Implements Pushed Authorization Requests (PAR) to support client-initiated authorization without user interaction. Adds a new endpoint to push authorization requests and return a request URI. Extends the authorize endpoint to handle these requests. Introduces `PARRequestStorage` protocol with `InMemoryPARStorage` and `RedisPARStorage` implementations for customizable storage options. Enhances automated authorization flow capabilities for improved client experience.

Closes #7