### PR TITLE
Remove unused JWT import from TokenManager

### DIFF
--- a/Sources/VaporOAuth/Protocols/TokenManager.swift
+++ b/Sources/VaporOAuth/Protocols/TokenManager.swift
@@ -1,5 +1,4 @@
 import Vapor
-import JWT
 
 public protocol TokenManager: Sendable {
     func generateAccessRefreshTokens(


### PR DESCRIPTION
- Remove unnecessary import of JWT package from TokenManager.swift
- Clean up dependencies in protocol definition