### PR TITLE
Improve protocol handling in OAuth2 initialization

### DIFF
--- a/Sources/VaporOAuth/OAuth2.swift
+++ b/Sources/VaporOAuth/OAuth2.swift
@@ -48,12 +48,12 @@ public struct OAuth2: LifecycleHandler {
     ///   - oAuthHelper: Helper service for OAuth operations
     ///   - metadataProvider: Service for providing server metadata
     public init(
-        codeManager: CodeManager = EmptyCodeManager(),
-        tokenManager: TokenManager,
-        deviceCodeManager: DeviceCodeManager = EmptyDeviceCodeManager(),
-        clientRetriever: ClientRetriever,
-        authorizeHandler: AuthorizeHandler = EmptyAuthorizationHandler(),
-        userManager: UserManager = EmptyUserManager(),
+        codeManager: any CodeManager = EmptyCodeManager(),
+        tokenManager: any TokenManager,
+        deviceCodeManager: any DeviceCodeManager = EmptyDeviceCodeManager(),
+        clientRetriever: any ClientRetriever,
+        authorizeHandler: any AuthorizeHandler = EmptyAuthorizationHandler(),
+        userManager: any UserManager = EmptyUserManager(),
         validScopes: [String]? = nil,
         resourceServerRetriever: any ResourceServerRetriever = EmptyResourceServerRetriever(),
         oAuthHelper: OAuthHelper,

--- a/Sources/VaporOAuth/Protocols/TokenManager.swift
+++ b/Sources/VaporOAuth/Protocols/TokenManager.swift
@@ -1,5 +1,4 @@
 import Vapor
-import JWT
 
 public protocol TokenManager: Sendable {
     func generateAccessRefreshTokens(

--- a/Tests/VaporOAuthTests/Helpers/TestDataBuilder.swift
+++ b/Tests/VaporOAuthTests/Helpers/TestDataBuilder.swift
@@ -37,7 +37,7 @@ class TestDataBuilder {
         
         app.lifecycle.use(
             OAuth2(
-                issuer: issuer, codeManager: codeManager,
+                codeManager: codeManager,
                 tokenManager: tokenManager,
                 deviceCodeManager: deviceCodeManager,
                 clientRetriever: clientRetriever,

--- a/Tests/VaporOAuthTests/IntegrationTests/AuthCodeResourceServerTests.swift
+++ b/Tests/VaporOAuthTests/IntegrationTests/AuthCodeResourceServerTests.swift
@@ -43,7 +43,7 @@ class AuthCodeResourceServerTests: XCTestCase {
         fakeUserManager.users.append(newUser)
 
         let oauthProvider = OAuth2(
-            issuer: issuer, codeManager: fakeCodeManager,
+            codeManager: fakeCodeManager,
             tokenManager: fakeTokenManager,
             clientRetriever: clientRetriever,
             authorizeHandler: capturingAuthouriseHandler,

--- a/Tests/VaporOAuthTests/MetadataTests/MetadataEndpointTests.swift
+++ b/Tests/VaporOAuthTests/MetadataTests/MetadataEndpointTests.swift
@@ -19,8 +19,6 @@ class MetadataEndpointTests: XCTestCase {
     
     func testRequiredRFCFields() async throws {
         let oauthProvider = OAuth2(
-            issuer: issuer,
-            jwksEndpoint: jwksEndpoint,
             tokenManager: FakeTokenManager(),
             clientRetriever: StaticClientRetriever(clients: []),
             oAuthHelper: .local(
@@ -53,8 +51,6 @@ class MetadataEndpointTests: XCTestCase {
         let validScopes = ["profile", "email"]
         
         let oauthProvider = OAuth2(
-            issuer: issuer,
-            jwksEndpoint: jwksEndpoint,
             codeManager: FakeCodeManager(),
             tokenManager: FakeTokenManager(),
             deviceCodeManager: FakeDeviceCodeManager(),
@@ -136,8 +132,6 @@ class MetadataEndpointTests: XCTestCase {
         }
         
         let oauthProvider = OAuth2(
-            issuer: issuer,
-            jwksEndpoint: jwksEndpoint,
             tokenManager: FakeTokenManager(),
             clientRetriever: StaticClientRetriever(clients: []),
             oAuthHelper: .local(
@@ -184,8 +178,6 @@ class MetadataEndpointTests: XCTestCase {
     // MARK: - Error Cases
     func testMetadataEndpointRequiredHeaders() async throws {
         let oauthProvider = OAuth2(
-            issuer: issuer,
-            jwksEndpoint: jwksEndpoint,
             tokenManager: FakeTokenManager(),
             clientRetriever: StaticClientRetriever(clients: []),
             oAuthHelper: .local(


### PR DESCRIPTION
- Added explicit 'any' keyword for protocol type parameters to enhance clarity.  
- Removed redundant `issuer` parameter from test initializations to streamline test configuration.  
- Eliminated unused `jwksEndpoint` parameter from metadata tests.  
- Cleaned up OAuth2 initializer parameter declarations for improved maintainability and consistency.